### PR TITLE
Added Cryo element and Endothermic Blaster legendary

### DIFF
--- a/src/main/kotlin/maliwan/mcbl/entity/Entities.kt
+++ b/src/main/kotlin/maliwan/mcbl/entity/Entities.kt
@@ -87,6 +87,12 @@ fun LivingEntity.temporarilyDisableIframes(plugin: MCBorderlandsPlugin) {
 }
 
 /**
+ * Get the location of the entity around the centered y-position.
+ */
+val Entity.centre: Location
+    get() = location.add(0.0, height / 2.0, 0.0)
+
+/**
  * Calculates for each type of living entity what the head position of the entity is.
  *
  * This is not the same as eye location: that is (I guess) the origin of the head from which the head rotation

--- a/src/main/kotlin/maliwan/mcbl/entity/HealthBar.kt
+++ b/src/main/kotlin/maliwan/mcbl/entity/HealthBar.kt
@@ -22,6 +22,7 @@ fun LivingEntity.showHealthBar(
         Elemental.CORROSIVE -> "${chatColor}C"
         Elemental.SHOCK -> "${chatColor}E"
         Elemental.SLAG -> "${chatColor}S"
+        Elemental.CRYO -> "${chatColor}I"
         else -> ""
     }
 
@@ -55,7 +56,7 @@ fun LivingEntity.showHealthBar(
     smallThreshold: Double = 19.5,
     color: ChatColor = ChatColor.RED
 ) {
-    val effects = plugin.weaponEventHandler.elementalStatusEffects.activeEffets(this)
+    val effects = plugin.weaponEventHandler.elementalStatusEffects.activeEffects(this)
         .map { (effect, _) -> effect.elemental }
     showHealthBar(smallLength, largeLength, smallThreshold, color, effects)
 }

--- a/src/main/kotlin/maliwan/mcbl/loot/LootPool.kt
+++ b/src/main/kotlin/maliwan/mcbl/loot/LootPool.kt
@@ -155,14 +155,16 @@ fun elementalLootPool(
     shock: Int,
     corrosive: Int,
     slag: Int,
-    explosive: Int
+    explosive: Int,
+    cryo: Int,
 ): LootPool<Elemental> = lootPoolOf(
     Elemental.PHYSICAL to nonElemental,
     Elemental.INCENDIARY to incendiary,
     Elemental.SHOCK to shock,
     Elemental.CORROSIVE to corrosive,
     Elemental.SLAG to slag,
-    Elemental.EXPLOSIVE to explosive
+    Elemental.EXPLOSIVE to explosive,
+    Elemental.CRYO to cryo
 )
 
 /**

--- a/src/main/kotlin/maliwan/mcbl/loot/gen/CapacitorTable.kt
+++ b/src/main/kotlin/maliwan/mcbl/loot/gen/CapacitorTable.kt
@@ -12,37 +12,37 @@ object CapacitorTable {
     /**
      * Equal chance for all elements or NE to show up, explosive is an exception as it is somewhat rarer.
      */
-    val elementAll = capacitorLootPool(100, 100, 100, 100, 100, 10)
+    val elementAll = capacitorLootPool(100, 100, 100, 100, 100, 10, 50)
 
     /**
      * Can only roll elemental capacitors.
      */
-    val elementOnly = capacitorLootPool(0, 100, 100, 100, 100, 10)
+    val elementOnly = capacitorLootPool(0, 100, 100, 100, 100, 10, 50)
 
     /**
      * Will roll elemental capacitors most of the time.
      */
-    val elementOften = capacitorLootPool(10, 100, 100, 100, 100, 1)
+    val elementOften = capacitorLootPool(10, 100, 100, 100, 100, 1, 50)
 
     /**
      * Will only roll elemental capacitors sometimes.
      */
-    val elementSome = capacitorLootPool(100, 10, 10, 10, 10, 1)
+    val elementSome = capacitorLootPool(100, 10, 10, 10, 10, 1, 5)
 
     /**
      * Equal chance for all elements to show up except explosive.
      */
-    val elementOnlyNoExplosive = capacitorLootPool(0, 100, 100, 100, 100, 0)
+    val elementOnlyNoExplosive = capacitorLootPool(0, 100, 100, 100, 100, 0, 50)
 
     /**
      * Will never roll elemental capacitors, but sometimes explosive.
      */
-    val elementNoneButExplosive = capacitorLootPool(100, 0, 0, 0, 0, 10)
+    val elementNoneButExplosive = capacitorLootPool(100, 0, 0, 0, 0, 10, 0)
 
     /**
      * Will never roll any elemental capacitor.
      */
-    val elementNone = capacitorLootPool(100, 0, 0, 0, 0, 0)
+    val elementNone = capacitorLootPool(100, 0, 0, 0, 0, 0, 0)
 
     /**
      * Creates a new loot pool for rarities based on the given weights.
@@ -53,13 +53,15 @@ object CapacitorTable {
         shock: Int,
         corrosive: Int,
         slag: Int,
-        explosive: Int
+        explosive: Int,
+        cryo: Int,
     ): LootPool<Capacitor> = lootPoolOf(
         Capacitor.NONE to nonElemental,
         Capacitor.INCENDIARY to incendiary,
         Capacitor.SHOCK to shock,
         Capacitor.CORROSIVE to corrosive,
         Capacitor.SLAG to slag,
-        Capacitor.EXPLOSIVE to explosive
+        Capacitor.EXPLOSIVE to explosive,
+        Capacitor.CRYO to cryo
     )
 }

--- a/src/main/kotlin/maliwan/mcbl/loot/gen/WeaponGenerator.kt
+++ b/src/main/kotlin/maliwan/mcbl/loot/gen/WeaponGenerator.kt
@@ -150,6 +150,7 @@ open class WeaponGenerator(
 
         applyGradeScaling()
         addManufacturerGimmick(assembly)
+        updateElementalChances()
 
         assembly.applyCustomLore(this)
 
@@ -158,6 +159,22 @@ open class WeaponGenerator(
         }
 
         return this
+    }
+
+    /**
+     * Post processes the elemental chance.
+     */
+    private fun GunProperties.updateElementalChances() {
+        val baseChance = elementalProbability[Elemental.CRYO] ?: return
+        val multiplier = when (weaponClass) {
+            WeaponClass.PISTOL -> 1.3
+            WeaponClass.SHOTGUN -> 1.0
+            WeaponClass.ASSAULT_RIFLE -> 1.0
+            WeaponClass.SNIPER -> 1.5
+            WeaponClass.SMG -> 0.5
+            WeaponClass.LAUNCHER -> 1.0
+        }
+        elementalProbability[Elemental.CRYO] = Probability(baseChance.chance * multiplier)
     }
 
     /**
@@ -247,6 +264,7 @@ open class WeaponGenerator(
             Elemental.CORROSIVE,
             Elemental.SHOCK,
             Elemental.SLAG -> 0.833
+            Elemental.CRYO -> 0.95
             else -> 1.0
         }
         baseDamage *= damageMultiplier

--- a/src/main/kotlin/maliwan/mcbl/weapons/BulletMeta.kt
+++ b/src/main/kotlin/maliwan/mcbl/weapons/BulletMeta.kt
@@ -30,7 +30,7 @@ data class BulletMeta(
     /**
      * Downward acceleration (+ value is downward, - is upward) of the bullet.
      */
-    val gravity: Double = 0.016,
+    var gravity: Double = 0.016,
 
     /**
      * How long the bullet stays alive.
@@ -135,7 +135,17 @@ data class BulletMeta(
      * 0.0-1.0 means that only part of the armour reduction is applied.
      * 0.0 means that the regular armour reduction is applied.
      */
-    var armourPenetration: Double = 0.0
+    var armourPenetration: Double = 0.0,
+
+    /**
+     * Whether this bullet can score critical hits (`true`) or not (`false`).
+     */
+    var canCrit: Boolean = true,
+
+    /**
+     * How many particles to show per tick during flight.
+     */
+    var particleCount: () -> Int =  { 1 },
 ) {
 
     /**

--- a/src/main/kotlin/maliwan/mcbl/weapons/Elemental.kt
+++ b/src/main/kotlin/maliwan/mcbl/weapons/Elemental.kt
@@ -16,12 +16,43 @@ enum class Elemental(
     val baseDotDuration: Ticks
 ) {
 
+    /**
+     * Regular damage.
+     */
     PHYSICAL("", ChatColor.WHITE.toString(), "⚔", Color.WHITE, Ticks(0)),
+
+    /**
+     * Weaker against fish and armored targets. Neutral to the rest.
+     */
     EXPLOSIVE("Explosive", ChatColor.YELLOW.toString(), "\uD83D\uDCA3", Color.YELLOW, Ticks(0)),
+
+    /**
+     * Strong against flesh and birds, weaker against the rest.
+     */
     INCENDIARY("Incendiary", ChatColor.GOLD.toString(), "\uD83D\uDD25", Color.ORANGE, Ticks(100)),
+
+    /**
+     * Strong against armour, weak against flesh.
+     */
     SHOCK("Shock", ChatColor.BLUE.toString(), "⚡", Color.fromRGB(37, 150, 190), Ticks(40)),
+
+    /**
+     * Strong against undead and armour, weak against flesh and bird.
+     */
     CORROSIVE("Corrosive", ChatColor.GREEN.toString(), "☣", Color.LIME, Ticks(160)),
-    SLAG("Slag", ChatColor.DARK_PURPLE.toString(), "⬇", Color.PURPLE, Ticks(160))
+
+    /**
+     * Slagged enemies take x2 damage from other damage sources.
+     */
+    SLAG("Slag", ChatColor.DARK_PURPLE.toString(), "⬇", Color.PURPLE, Ticks(160)),
+
+    /**
+     * Effect depends on amount of Cryo stacks:
+     * - 1-2 stacks: +50% explosive/melee damage, Slowness I
+     * - 3-4 stacks: +150% explosive/melee damage, Slowness II
+     * - 5 stacks: +250% explosive/melee damage, Frozen Solid/no movement.
+     */
+    CRYO("Cryo", ChatColor.AQUA.toString(), "❄", Color.AQUA, Ticks(160))
     ;
 
     val nullIfPhysical: Elemental?
@@ -32,7 +63,7 @@ enum class Elemental(
      */
     val noDotMultiplier: Double
         get() = when (this) {
-            PHYSICAL, SLAG, EXPLOSIVE -> 0.0
+            PHYSICAL, SLAG, EXPLOSIVE, CRYO -> 0.0
             else -> 1.0
         }
 }
@@ -102,6 +133,7 @@ enum class EffectivenessType(
             Elemental.SHOCK to 0.6,
             Elemental.CORROSIVE to 0.8,
             Elemental.SLAG to 1.0,
+            Elemental.CRYO to 1.0
         )
     ),
 
@@ -130,6 +162,7 @@ enum class EffectivenessType(
             Elemental.SHOCK to 1.5,
             Elemental.CORROSIVE to 1.0,
             Elemental.SLAG to 1.0,
+            Elemental.CRYO to 1.5
         )
     ),
 
@@ -151,6 +184,7 @@ enum class EffectivenessType(
             Elemental.SHOCK to 1.5,
             Elemental.CORROSIVE to 0.8,
             Elemental.SLAG to 1.0,
+            Elemental.CRYO to 1.0
         )
     ),
 
@@ -175,6 +209,7 @@ enum class EffectivenessType(
             Elemental.SHOCK to 1.0,
             Elemental.CORROSIVE to 1.0,
             Elemental.SLAG to 1.0,
+            Elemental.CRYO to 0.8
         )
     ),
 
@@ -199,6 +234,7 @@ enum class EffectivenessType(
             Elemental.SHOCK to 1.2,
             Elemental.CORROSIVE to 1.0,
             Elemental.SLAG to 1.0,
+            Elemental.CRYO to 1.5
         )
     ),
 
@@ -227,6 +263,7 @@ enum class EffectivenessType(
             Elemental.SHOCK to 1.0,
             Elemental.CORROSIVE to 1.5,
             Elemental.SLAG to 1.0,
+            Elemental.CRYO to 1.0
         )
     ),
 
@@ -243,6 +280,7 @@ enum class EffectivenessType(
             Elemental.SHOCK to 2.0,
             Elemental.CORROSIVE to 1.2,
             Elemental.SLAG to 1.0,
+            Elemental.CRYO to 1.0
         )
     )
     ;

--- a/src/main/kotlin/maliwan/mcbl/weapons/WeaponEventHandler.kt
+++ b/src/main/kotlin/maliwan/mcbl/weapons/WeaponEventHandler.kt
@@ -206,7 +206,12 @@ class WeaponEventHandler(val plugin: MCBorderlandsPlugin) : Listener, Runnable {
         repeat(gunExecution.pelletCount) { _ ->
             shootGunBullet(player, gunExecution)?.let { bullets.add(it) }
         }
-        player.playSound(player.location, Sound.ENTITY_FIREWORK_ROCKET_BLAST, SoundCategory.PLAYERS, 5.0f, 1.0f)
+
+        // Play gun sound.
+        val soundProvider = gunExecution.assembly?.behaviours
+            ?.firstOrNull { it is BulletSoundProvider } as? BulletSoundProvider
+        val sound = soundProvider?.shootSound ?: Sound.ENTITY_FIREWORK_ROCKET_BLAST
+        player.playSound(player.location, sound, SoundCategory.PLAYERS, 5.0f, 1.0f)
 
         if (consumeAmmo) {
             removeAmmo(player, gunExecution)
@@ -315,7 +320,23 @@ class WeaponEventHandler(val plugin: MCBorderlandsPlugin) : Listener, Runnable {
         } else false
     }
 
-    fun shootGunBullet(player: LivingEntity, gunExecution: GunExecution, directionDelta: Vector? = null): Entity? {
+    /**
+     * Shoots a bullet.
+     *
+     * @param player Who shoots the bullet.
+     * @param gunExecution The gun execution of the gun that shoots the bullet.
+     * @param directionDelta Translation of the initial shooting direction.
+     * @param bulletMetaTransform Transformation function that modifies the bullet meta before shooting.
+     * @param accuracyModifier With how much to fuzz the initial direction, 0.0 for perfect accuracy, `null` for the
+     * default accuracy modifier.
+     */
+    fun shootGunBullet(
+        player: LivingEntity,
+        gunExecution: GunExecution,
+        directionDelta: Vector? = null,
+        bulletMetaTransform: ((BulletMeta) -> Unit)? = null,
+        accuracyModifier: Double? = null
+    ): Entity? {
         val bulletType = gunExecution.assembly?.behaviours?.first<BulletTypeProvider, EntityType> {
             it.bulletType
         } ?: EntityType.ARROW
@@ -324,8 +345,9 @@ class WeaponEventHandler(val plugin: MCBorderlandsPlugin) : Listener, Runnable {
         val initialDirection = gunExecution.bulletPattern.nextRotation(playerDirection)
         val direction = initialDirection.add(directionDelta ?: Vector())
 
-        val bullet = player.shootBullet(player.eyeLocation, direction, gunExecution, bulletType) ?: return null
+        val bullet = player.shootBullet(player.eyeLocation, direction, gunExecution, bulletType, accuracyModifier) ?: return null
         val bulletMeta = gunExecution.bulletMeta(player)
+        bulletMetaTransform?.let { it(bulletMeta) }
         bullets[bullet] = bulletMeta
 
         val millisDelay = (1000.0 / gunExecution.fireRate).toLong()
@@ -401,7 +423,7 @@ class WeaponEventHandler(val plugin: MCBorderlandsPlugin) : Listener, Runnable {
         val distance = hitLocation?.distance(head) ?: Double.MAX_VALUE
         val isCritical = distance < targetEntity.headshotRange * 1.15 /* make it slightly easier to hit headshots */
 
-        val critMultiplier = if (isCritical) {
+        val critMultiplier = if (isCritical && bulletMeta.canCrit) {
             2.0 + (bulletMeta.bonusCritMultiplier ?: 0.0)
         }
         else 1.0

--- a/src/main/kotlin/maliwan/mcbl/weapons/WeaponParticles.kt
+++ b/src/main/kotlin/maliwan/mcbl/weapons/WeaponParticles.kt
@@ -37,6 +37,9 @@ open class WeaponParticles(val weaponHandler: WeaponEventHandler, val everyNtick
                 if (Elemental.SLAG in meta.elements) {
                     bullet.location.showElementalParticle(Elemental.SLAG.color, 1, 0.6f)
                 }
+                if (Elemental.CRYO in meta.elements) {
+                    bullet.location.showElementalParticle(Elemental.CRYO.color, 1, 0.6f)
+                }
             }
     }
 }

--- a/src/main/kotlin/maliwan/mcbl/weapons/WeaponParticles.kt
+++ b/src/main/kotlin/maliwan/mcbl/weapons/WeaponParticles.kt
@@ -26,19 +26,19 @@ open class WeaponParticles(val weaponHandler: WeaponEventHandler, val everyNtick
                     bullet.location.world?.playEffect(bullet.location.add(0.0, 0.5, 0.0), Effect.SMOKE, 0)
                 }
                 if (Elemental.INCENDIARY in meta.elements) {
-                    bullet.location.showElementalParticle(Elemental.INCENDIARY.color, 1, 0.6f)
+                    bullet.location.showElementalParticle(Elemental.INCENDIARY.color, meta.particleCount(), 0.6f)
                 }
                 if (Elemental.CORROSIVE in meta.elements) {
-                    bullet.location.showElementalParticle(Elemental.CORROSIVE.color, 1, 0.6f)
+                    bullet.location.showElementalParticle(Elemental.CORROSIVE.color, meta.particleCount(), 0.6f)
                 }
                 if (Elemental.SHOCK in meta.elements) {
-                    bullet.location.showElementalParticle(Elemental.SHOCK.color, 1, 0.6f)
+                    bullet.location.showElementalParticle(Elemental.SHOCK.color, meta.particleCount(), 0.6f)
                 }
                 if (Elemental.SLAG in meta.elements) {
-                    bullet.location.showElementalParticle(Elemental.SLAG.color, 1, 0.6f)
+                    bullet.location.showElementalParticle(Elemental.SLAG.color, meta.particleCount(), 0.6f)
                 }
                 if (Elemental.CRYO in meta.elements) {
-                    bullet.location.showElementalParticle(Elemental.CRYO.color, 1, 0.6f)
+                    bullet.location.showElementalParticle(Elemental.CRYO.color, meta.particleCount(), 0.6f)
                 }
             }
     }

--- a/src/main/kotlin/maliwan/mcbl/weapons/gun/GunProperties.kt
+++ b/src/main/kotlin/maliwan/mcbl/weapons/gun/GunProperties.kt
@@ -4,6 +4,7 @@ import maliwan.mcbl.Keys
 import maliwan.mcbl.util.*
 import maliwan.mcbl.weapons.*
 import maliwan.mcbl.weapons.gun.behaviour.FibWeaponCard
+import maliwan.mcbl.weapons.gun.behaviour.OverrideManufacturerOnWeaponCard
 import org.bukkit.ChatColor
 import org.bukkit.entity.Item
 import org.bukkit.entity.LivingEntity
@@ -441,7 +442,12 @@ open class GunProperties(
     }
 
     private fun MutableList<String>.addGunTypeToCard() {
-        this += "${ChatColor.GRAY}${rarity.displayName} • ${weaponClass.displayName} • ${manufacturer.displayName}"
+        val manufacturerNameUpdater = assembly?.behaviours?.firstOrNull {
+            it is OverrideManufacturerOnWeaponCard
+        } as? OverrideManufacturerOnWeaponCard
+
+        val manufacturerName = manufacturerNameUpdater?.newManufacturerName(manufacturer.displayName) ?: manufacturer.displayName
+        this += "${ChatColor.GRAY}${rarity.displayName} • ${weaponClass.displayName} • $manufacturerName"
     }
 
     private fun MutableList<String>.addBaseStatsToCard(fib: FibWeaponCard?) {

--- a/src/main/kotlin/maliwan/mcbl/weapons/gun/GunProperties.kt
+++ b/src/main/kotlin/maliwan/mcbl/weapons/gun/GunProperties.kt
@@ -411,6 +411,10 @@ open class GunProperties(
                     lore += "${ChatColor.WHITE}•${element.chatColor} Slagged entities take additional"
                     lore += "${element.chatColor}non-slag damage"
                 }
+                Elemental.CRYO -> {
+                    placeSeparator()
+                    lore += "${ChatColor.WHITE}•${element.chatColor} Slows and freezes entities"
+                }
                 else -> {}
             }
         }

--- a/src/main/kotlin/maliwan/mcbl/weapons/gun/GunShot.kt
+++ b/src/main/kotlin/maliwan/mcbl/weapons/gun/GunShot.kt
@@ -14,15 +14,16 @@ fun LivingEntity.shootBullet(
     from: Location,
     direction: Vector,
     properties: GunProperties,
-    bulletType: EntityType = EntityType.ARROW
+    bulletType: EntityType = EntityType.ARROW,
+    accuracyModifier: Double? = null
 ): Projectile? {
     val world = from.world ?: return null
 
-    val accuracyModifier = (1.0 - properties.accuracy.chance) * 0.375
+    val accuracyModifierValue = accuracyModifier ?: ((1.0 - properties.accuracy.chance) * 0.375)
     val newDirection = direction
-        .setX(direction.x.modifyRandom(accuracyModifier))
-        .setY(direction.y.modifyRandom(accuracyModifier))
-        .setZ(direction.z.modifyRandom(accuracyModifier))
+        .setX(direction.x.modifyRandom(accuracyModifierValue))
+        .setY(direction.y.modifyRandom(accuracyModifierValue))
+        .setZ(direction.z.modifyRandom(accuracyModifierValue))
 
     val bullet = world.spawnEntity(from, bulletType) as? Projectile
         ?: error("Entity type $bulletType is not a projectile.")

--- a/src/main/kotlin/maliwan/mcbl/weapons/gun/StatModifier.kt
+++ b/src/main/kotlin/maliwan/mcbl/weapons/gun/StatModifier.kt
@@ -194,13 +194,15 @@ open class StatModifier(
  */
 fun List<StatModifier>.ofType(type: StatModifier.Type) = filter { it.type == type }
 
+fun GunProperties.apply(operation: StatModifier) {
+    operation.applyStatModifier(this)
+}
+
 /**
  * Applies these stat modifiers in order, and with a certain operator precedence defined in `order`.
  *
- * @param properties
- *          The gun properties to apply the stat modifiers to.
- * @param order
- *          In which operator precedence, see [StatModifier.Type].
+ * @param properties The gun properties to apply the stat modifiers to.
+ * @param order In which operator precedence, see [StatModifier.Type].
  */
 fun List<StatModifier>.applyAll(
     properties: GunProperties,

--- a/src/main/kotlin/maliwan/mcbl/weapons/gun/behaviour/GunBehaviour.kt
+++ b/src/main/kotlin/maliwan/mcbl/weapons/gun/behaviour/GunBehaviour.kt
@@ -8,6 +8,7 @@ import maliwan.mcbl.weapons.gun.GunProperties
 import maliwan.mcbl.weapons.gun.WeaponAssembly
 import maliwan.mcbl.weapons.gun.pattern.BulletPatternProcessor
 import org.bukkit.Location
+import org.bukkit.Sound
 import org.bukkit.entity.*
 
 /**
@@ -183,13 +184,24 @@ interface PostGenerationBehaviour : GunBehaviour {
 /**
  * Determines which type of projectile the gun shoots.
  */
-interface BulletTypeProvider: GunBehaviour {
+interface BulletTypeProvider : GunBehaviour {
 
     /**
      * The type of bullet that gets shot.
      * Must be a [Projectile].
      */
     val bulletType: EntityType
+}
+
+/**
+ * Determines which sound to play when the gun fires.
+ */
+interface BulletSoundProvider : GunBehaviour {
+
+    /**
+     * The sound to play when the gun gets fired.
+     */
+    val shootSound: Sound
 }
 
 /**
@@ -341,6 +353,20 @@ interface FibWeaponCard : GunBehaviour {
      * For example: manufacturer gimmicks, transfusion percentages, bonus elemental damage...
      */
     val showGeneratedInfo: Boolean
+}
+
+/**
+ * Modifies the name of the manufacturer shown on the weapon card.
+ */
+interface OverrideManufacturerOnWeaponCard : GunBehaviour {
+
+    /**
+     * Get the manufacturer name that must be shown on the weapon card.
+     *
+     * @param oldName The original manufacturer name.
+     * @return The new manufacturer name on the weapon card.
+     */
+    fun newManufacturerName(oldName: String): String
 }
 
 inline fun <reified T> List<GunBehaviour>.forEachType(action: (T) -> Unit) {

--- a/src/main/kotlin/maliwan/mcbl/weapons/gun/behaviour/shotgun/Butcher.kt
+++ b/src/main/kotlin/maliwan/mcbl/weapons/gun/behaviour/shotgun/Butcher.kt
@@ -37,7 +37,7 @@ open class Butcher : UniqueGun, PostGunShotBehaviour, PostGenerationBehaviour {
         player: Player
     ) {
         if (Random.nextDouble() < 0.5) {
-            val addAmmo = Random.nextInt(0, 3)
+            val addAmmo = Random.nextInt(1, 4)
             execution.clip = min(execution.clip + addAmmo, execution.magazineSize)
         }
     }
@@ -47,7 +47,7 @@ open class Butcher : UniqueGun, PostGunShotBehaviour, PostGenerationBehaviour {
         val statModifiers = statModifierList {
             multiply(2.0, StatModifier.Property.ACCURACY)
             multiply(2.5, StatModifier.Property.FIRE_RATE)
-            add(1, StatModifier.Property.MAGAZINE_SIZE)
+            add(2, StatModifier.Property.MAGAZINE_SIZE)
         }
     }
 }

--- a/src/main/kotlin/maliwan/mcbl/weapons/gun/behaviour/shotgun/Overcompensator.kt
+++ b/src/main/kotlin/maliwan/mcbl/weapons/gun/behaviour/shotgun/Overcompensator.kt
@@ -66,7 +66,7 @@ open class Overcompensator : UniqueGun, PostGunShotBehaviour, PostGenerationBeha
         val statModifiers = statModifierList {
             multiply(2.25, StatModifier.Property.ACCURACY)
             multiply(2, StatModifier.Property.FIRE_RATE)
-            add(2, StatModifier.Property.MAGAZINE_SIZE)
+            add(1, StatModifier.Property.MAGAZINE_SIZE)
         }
     }
 }

--- a/src/main/kotlin/maliwan/mcbl/weapons/gun/behaviour/shotgun/Overcompensator.kt
+++ b/src/main/kotlin/maliwan/mcbl/weapons/gun/behaviour/shotgun/Overcompensator.kt
@@ -17,7 +17,7 @@ open class Overcompensator : UniqueGun, PostGunShotBehaviour, PostGenerationBeha
     TalkWhenFiring, TalkWhenReloading {
 
     override val baseName = "Overcompensator"
-    override val redText = "Fresh meat!"
+    override val redText = "You can either surf, or you can fight!"
 
     override val talkChanceFiring = Probability(0.1)
     override val talkMessagesFiring = listOf(

--- a/src/main/kotlin/maliwan/mcbl/weapons/gun/behaviour/smg/EndothermicBlaster.kt
+++ b/src/main/kotlin/maliwan/mcbl/weapons/gun/behaviour/smg/EndothermicBlaster.kt
@@ -1,0 +1,140 @@
+package maliwan.mcbl.weapons.gun.behaviour.smg
+
+import maliwan.mcbl.loot.ammo.AmmoPack
+import maliwan.mcbl.util.Ticks
+import maliwan.mcbl.util.scheduleTask
+import maliwan.mcbl.weapons.WeaponClass
+import maliwan.mcbl.weapons.WeaponEventHandler
+import maliwan.mcbl.weapons.gun.*
+import maliwan.mcbl.weapons.gun.behaviour.*
+import maliwan.mcbl.weapons.gun.parts.Capacitor
+import maliwan.mcbl.weapons.gun.parts.SmgParts
+import org.bukkit.Sound
+import org.bukkit.SoundCategory
+import org.bukkit.entity.Entity
+import org.bukkit.entity.Player
+import kotlin.math.max
+import kotlin.random.Random
+
+/**
+ * @author Hannah Schellekens
+ */
+open class EndothermicBlaster(
+
+    /**
+     * How long it takes for alt fire to shoot.
+     */
+    val windupMillis: Long = 800L
+
+) : UniqueGun, PostGenerationBehaviour, UpdateAssemblyBehaviour,
+    OverrideManufacturerOnWeaponCard, DefaultPrefixProvider, PostGunShotBehaviour, BulletSoundProvider {
+
+    override val baseName = "Endothermic Blaster"
+    override val redText = "Sorry! Sorry, I'm sorry. Sorry."
+    override val defaultPrefix = ""
+    override val shootSound = Sound.BLOCK_POWDER_SNOW_STEP
+
+    override fun onFinishGeneration(properties: GunProperties, assembly: WeaponAssembly) {
+        SmgParts.Barrel.MALIWAN.applyStatModifiers(properties)
+        statModifiers.applyAll(properties)
+
+        properties.gravity = 0.0
+        properties.bulletSpeed = 20.0
+        properties.isPiercing = true
+        properties.reloadSpeed = Ticks(30)
+        properties.splashDamage = properties.baseDamage * 0.5
+
+        properties.extraInfoText += "Crouch while shooting for highly accurate\nicicles with +150% critical damage"
+    }
+
+    override fun updateAssembly(assembly: WeaponAssembly): WeaponAssembly {
+        // Always cryo.
+        return assembly.replaceCapacitor(Capacitor.CRYO)
+    }
+
+    override fun afterGunShot(
+        handler: WeaponEventHandler,
+        execution: GunExecution,
+        bullets: List<Entity>,
+        player: Player
+    ) {
+        val altFire = player.isSneaking
+
+        // Alternative, sniper mode.
+        if (altFire) {
+            val data = execution.executionData<ExecutionData>() ?: ExecutionData()
+
+            // Counteract SMG behaviour.
+            bullets.forEach {
+                handler.unregisterBullet(it)
+                it.remove()
+
+                execution.clip += 1
+                handler.plugin.inventoryManager[player].add(ammoCompensation)
+            }
+
+            // Shoot sniper icicle.
+            if (data.isWindingUp.not()) {
+                data.isWindingUp = true
+                handler.plugin.scheduleTask(windupMillis / 50) {
+                    // Modify bullet behaviour to match a sniper icicle.
+                    execution.bulletSpeed = 70.0
+                    val oldFireRate = execution.fireRate
+                    execution.fireRate = 1.0 / 0.8
+                    handler.shootGunBullet(player, execution, bulletMetaTransform = {
+                        it.damage *= 3.5
+                        it.gravity = 0.0
+                        it.bonusCritMultiplier = 1.5
+                        it.isPiercing = false
+                    }, accuracyModifier = 0.0)
+                    execution.bulletSpeed = 20.0
+                    execution.fireRate = oldFireRate
+                    player.playSound(player.location, Sound.BLOCK_GLASS_BREAK, SoundCategory.PLAYERS, 0.6f, 1.0f)
+
+                    // Remove 4 ammo per shot instead of 1.
+                    val newClip = max(0, execution.clip - 5)
+                    val removed = execution.clip - newClip
+                    execution.clip = newClip
+                    handler.plugin.inventoryManager[player].removeAmmo(WeaponClass.SMG, removed)
+                    if (execution.clip <= 0) {
+                        handler.reloadGun(player, execution)
+                    }
+
+                    data.isWindingUp = false
+                    execution.setExecutionData(data)
+                }
+                execution.setExecutionData(data)
+            }
+            return
+        }
+
+        // Primary fire, flame/cryothrower.
+        bullets.forEach {
+            it.isVisibleByDefault = false
+
+            // Flamethrower-style: short range only!
+            val meta = handler.bullets[it]
+            meta?.deathTimestamp = System.currentTimeMillis() + 750L
+            meta?.bonusCritMultiplier = 0.5
+            meta?.canCrit = false
+            meta?.particleCount = { Random.nextInt(1, 5) }
+        }
+    }
+
+    override fun newManufacturerName(oldName: String): String = "Meiliwan"
+
+    data class ExecutionData(var isWindingUp: Boolean = false)
+
+    companion object {
+
+        val statModifiers = statModifierList {
+            subtract(0.025, StatModifier.Property.ACCURACY)
+            multiply(1.3, StatModifier.Property.FIRE_RATE)
+            multiply(1.6, StatModifier.Property.BASE_DAMAGE)
+            multiply(1.2, StatModifier.Property.MAGAZINE_SIZE)
+            multiply(1.2, StatModifier.Property.ELEMENTAL_CHANCE)
+        }
+
+        private val ammoCompensation = AmmoPack(WeaponClass.SMG, 1)
+    }
+}

--- a/src/main/kotlin/maliwan/mcbl/weapons/gun/names/WeaponNames.kt
+++ b/src/main/kotlin/maliwan/mcbl/weapons/gun/names/WeaponNames.kt
@@ -85,5 +85,5 @@ fun defaultPrefix(behaviours: List<GunBehaviour>): String? {
     return if (names.isEmpty()) {
         null
     }
-    else names.joinToString(" ")
+    else names.joinToString(" ").trim().ifBlank { null }
 }

--- a/src/main/kotlin/maliwan/mcbl/weapons/gun/parts/Capacitor.kt
+++ b/src/main/kotlin/maliwan/mcbl/weapons/gun/parts/Capacitor.kt
@@ -21,6 +21,7 @@ enum class Capacitor(elemental: Elemental, val partName: String, vararg behaviou
     CORROSIVE(Elemental.CORROSIVE, "Corrisove"),
     SLAG(Elemental.SLAG, "Slag"),
     EXPLOSIVE(Elemental.EXPLOSIVE, "Explosive"),
+    CRYO(Elemental.CRYO, "Cryo"),
 
     // Unique capacitors.
     HELLFIRE(Elemental.INCENDIARY, "HellFire", HellFire()), /* SMG */
@@ -45,12 +46,14 @@ enum class Capacitor(elemental: Elemental, val partName: String, vararg behaviou
             SHOCK,
             CORROSIVE,
             SLAG,
-            EXPLOSIVE
+            EXPLOSIVE,
+            CRYO
         )
 
         val legendaryCapacitors = setOf(
             HELLFIRE,
-            DEFILER
+            DEFILER,
+            VOLCANO
         )
     }
 }

--- a/src/main/kotlin/maliwan/mcbl/weapons/gun/parts/SmgParts.kt
+++ b/src/main/kotlin/maliwan/mcbl/weapons/gun/parts/SmgParts.kt
@@ -123,6 +123,7 @@ object SmgParts {
         CRIT(Manufacturer.HYPERION, "Crit", behaviours = listOf(Crit())),
         DOUBLE_ANARCHY(Manufacturer.TEDIORE, "Double Anarchy", behaviours = listOf(DoubleAnarchy())),
         EMPEROR(Manufacturer.DAHL, "Emperor", behaviours = listOf(Emperor())),
+        ENDOTHERMIC_BLASTER(Manufacturer.MALIWAN, "EndoBlaster", behaviours = listOf(EndothermicBlaster())),
         GOOD_TOUCH(Manufacturer.MALIWAN, "Good Touch", behaviours = listOf(GoodTouch())),
         SLAGGA(Manufacturer.BANDIT, "Slagga", behaviours = listOf(Slagga())),
         ;

--- a/src/main/kotlin/maliwan/mcbl/weapons/gun/parts/UniqueGunParts.kt
+++ b/src/main/kotlin/maliwan/mcbl/weapons/gun/parts/UniqueGunParts.kt
@@ -44,6 +44,7 @@ object UniqueGunParts {
         UniqueGunPart.UniqueWeaponPart(Manufacturer.MALIWAN, WeaponClass.PISTOL, PistolParts.Barrel.HELLSHOCK),
         UniqueGunPart.UniqueWeaponPart(Manufacturer.MALIWAN, WeaponClass.PISTOL, PistolParts.Barrel.THUNDERBALL_FISTS),
         UniqueGunPart.UniqueWeaponPart(Manufacturer.MALIWAN, WeaponClass.SMG, SmgParts.Grip.EMPTINESS),
+        UniqueGunPart.UniqueWeaponPart(Manufacturer.MALIWAN, WeaponClass.SMG, SmgParts.Barrel.ENDOTHERMIC_BLASTER),
         UniqueGunPart.UniqueCapacitor(Manufacturer.MALIWAN, WeaponClass.SMG, Capacitor.HELLFIRE),
         UniqueGunPart.UniqueCapacitor(Manufacturer.MALIWAN, WeaponClass.SNIPER, Capacitor.VOLCANO),
         UniqueGunPart.UniqueWeaponPart(Manufacturer.MALIWAN, WeaponClass.LAUNCHER, LauncherParts.Barrel.PYROPHOBIA),

--- a/src/main/resources/gun/names/launcher-maliwan-elements.csv
+++ b/src/main/resources/gun/names/launcher-maliwan-elements.csv
@@ -1,2 +1,2 @@
-	PHYSICAL	EXPLOSIVE	INCENDIARY	SHOCK	CORROSIVE	SLAG
-MALIWAN	Preternatural	Precipitating	Pyroclastic	Parelectronomic	Paraquat	Purulence
+	PHYSICAL	EXPLOSIVE	INCENDIARY	SHOCK	CORROSIVE	SLAG	CRYO
+MALIWAN	Preternatural	Precipitating	Pyroclastic	Parelectronomic	Paraquat	Purulence	Pagophilic

--- a/src/main/resources/gun/names/smg-names.csv
+++ b/src/main/resources/gun/names/smg-names.csv
@@ -1,6 +1,6 @@
 	BANDIT	MALIWAN	TEDIORE	DAHL	HYPERION	ERIDIAN
-BANDIT	Smig	Smig|Burny|Shoky|Barfy|Slagy	Smig	Rokgun	Acurate smgg	Plasma Caster
-DAHL	SMG	SMG|Beetle|Eel|Scorpion|Jackal	SMG	Fox	Falcon	Plasma Caster
-HYPERION	Projectile Convergence	Projectile Convergence|Backburner|Storm|Weisenheimer|Wellness	Projectile Convergence	Presence	Transmurdera	Plasma Caster
-MALIWAN	SubMalevolent Grace	SubMalevolent Grace|Provacateur|Vexation|Venom|Revenant	SubMalevolent Grace	Trance	Gospel	Plasma Caster
-TEDIORE	Subcompact MG	Subcompact MG|Kindle|Spark|Green|Chaff	Subcompact MG	Special	Ace	Plasma Caster
+BANDIT	Smig	Smig|Burny|Shoky|Barfy|Slagy|Freazy	Smig	Rokgun	Acurate smgg	Plasma Caster
+DAHL	SMG	SMG|Beetle|Eel|Scorpion|Jackal|Polar Bear	SMG	Fox	Falcon	Plasma Caster
+HYPERION	Projectile Convergence	Projectile Convergence|Backburner|Storm|Weisenheimer|Wellness|AC	Projectile Convergence	Presence	Transmurdera	Plasma Caster
+MALIWAN	SubMalevolent Grace	SubMalevolent Grace|Provacateur|Vexation|Venom|Revenant|Subzero	SubMalevolent Grace	Trance	Gospel	Plasma Caster
+TEDIORE	Subcompact MG	Subcompact MG|Kindle|Spark|Green|Chaff|Shiver	Subcompact MG	Special	Ace	Plasma Caster

--- a/src/main/resources/gun/names/weapon-elements.csv
+++ b/src/main/resources/gun/names/weapon-elements.csv
@@ -1,10 +1,10 @@
-	PHYSICAL	EXPLOSIVE	INCENDIARY	SHOCK	CORROSIVE	SLAG
-MALIWAN	Preternatural	Reverberating	Inflammatory	Electrified	Trenchant	Scoria
-DAHL		Explosive	Incendiary	Sapping	Corrosive	Amp
-HYPERION		Volatile	Hot Button	Energizing	Base	Amplified
-VLADOF		Exploding	Burning	Discharge	Caustic	Slag
-BANDIT		Exsploding	Fire Fire	Zapper	Crudy	Slaged
-JAKOBS		Dynamite	Kindle	Jolt	Eroding	Cinder
-TEDIORE		Combusting	Red Hot	Energizing	Pine Fresh	Disinfecting
-TORGUE			Arousing	Tickling	Naughty	Smokin'
-ATLAS		DDOS	Overclocked	High Voltage	Goto	Backdoor
+	PHYSICAL	EXPLOSIVE	INCENDIARY	SHOCK	CORROSIVE	SLAG	CRYO
+MALIWAN	Preternatural	Reverberating	Inflammatory	Electrified	Trenchant	Scoria	Crystalline
+DAHL		Explosive	Incendiary	Sapping	Corrosive	Amp	Freezing
+HYPERION		Volatile	Hot Button	Energizing	Base	Amplified	Chilled
+VLADOF		Exploding	Burning	Discharge	Caustic	Slag	Cold
+BANDIT		Exsploding	Fire Fire	Zapper	Crudy	Slaged	Frosty
+JAKOBS		Dynamite	Kindle	Jolt	Eroding	Cinder	Chill
+TEDIORE		Combusting	Red Hot	Energizing	Pine Fresh	Disinfecting	Refreshing
+TORGUE			Arousing	Tickling	Naughty	Smokin'	White
+ATLAS		DDOS	Overclocked	High Voltage	Goto	Backdoor	Coolant


### PR DESCRIPTION
Cryo:
- has no DoT (generally), is possible though;
- builds up stacks (ADD policy);
- for 1-2 stacks +50% explosive and melee damage, gives Slowness I;
- for 3-4 stacks +150% explosive and melee damage, gives Slowness II;
- for 5+ stacks +250% explosive/melee damage, freezes solid in movement;
- the more stacks, the more particle effects are visible;
- freeze effect is also applied, player experiences a freeze vignette;
- guns with cryo are less common than other elements;
- element efficacy is: 100% flesh, 150% fish, 100% bird, 80% non-flesh, 150% nether flesh, 100% undead, 100% armoured damage;
- birds do not fall down (yet);
- had to come up with a couple of fun freeze-related names for guns;
- elemental chances per gun are slightly modified for balance (SMGs have lower chance because a higher rate of fire) as cryo has a higher impact than other elements;
- color is aqua.

Endothermic Blaster:
- Flamethrower style weapon
- Has alt fire with sniper icicles on delay.
- BulletMeta canCrit property in bullet meta to enable/disable crits
- BulletMeta particleCount to produce the amount of particles to show during flight
- Gun sound can be modified with BulletSoundProvider behaviour